### PR TITLE
ethereum-cryptography-version-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@toruslabs/eccrypto": "^3.0.0",
     "@toruslabs/http-helpers": "^4.0.0",
     "elliptic": "^6.5.4",
-    "ethereum-cryptography": "^2.0.0",
+    "ethereum-cryptography": "2.0.0",
     "json-stable-stringify": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
removed carrot symbol, as new version not compatible.

<img width="1440" alt="Screenshot 2023-07-11 at 3 38 58 PM" src="https://github.com/torusresearch/metadata-helpers/assets/104764504/4d073fc2-bb58-4944-a58a-042527c8b400">
